### PR TITLE
suppert type of actino.type is Symbol.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -45,7 +45,7 @@ export function printBuffer(buffer, options) {
 
     const formattedTime = formatTime(startedTime);
     const titleCSS = colors.title ? `color: ${colors.title(formattedAction)};` : null;
-    const title = `action @ ${timestamp ? formattedTime : ``} ${formattedAction.type} ${duration ? `(in ${took.toFixed(2)} ms)` : ``}`;
+    const title = `action @ ${timestamp ? formattedTime : ``} ${formattedAction.type.toString()} ${duration ? `(in ${took.toFixed(2)} ms)` : ``}`;
 
     // Render
     try {


### PR DESCRIPTION
when my action.type is Symbol, `action = {type: Symbol("CALL HTTP API")}`.
redux-logger throw an error:  Cannot convert a Symbol value to a number.

so I fix it.